### PR TITLE
Fix `random` being undefined when using "Display horses"

### DIFF
--- a/screen/display.py
+++ b/screen/display.py
@@ -33,8 +33,8 @@ def display(parent_win):
     while True:
         for frame in frames:
             #start printing the frame in random places but not outside the screen
-            y = random.randint(0, sh - max_height -1)
-            x = random.randint(0, sw - max_width -1)
+            y = myrandom.randint(0, sh - max_height -1)
+            x = myrandom.randint(0, sw - max_width -1)
 
             #remove newlines from the frame
             frame = [line[:-1] for line in frame]


### PR DESCRIPTION
When using "Display horses", after the countdown, the program crashes with
```Traceback (most recent call last):
  File "/home/koraynilay/ASCII-horses/./main.py", line 120, in <module>
    curses.wrapper(main_handler)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/curses/__init__.py", line 94, in wrapper
    return func(stdscr, *args, **kwds)
  File "/home/koraynilay/ASCII-horses/./main.py", line 111, in main_handler
    display.display(win)
    ~~~~~~~~~~~~~~~^^^^^
  File "/home/koraynilay/ASCII-horses/screen/display.py", line 36, in display
    y = random.randint(0, sh - max_height -1)
        ^^^^^^
NameError: name 'random' is not defined. Did you mean: 'myrandom'? Or did you forget to import 'random'?
```
This PR fixes it.